### PR TITLE
Don't throw an exception on rolling release Linux distributions

### DIFF
--- a/src/sys_detection/__init__.py
+++ b/src/sys_detection/__init__.py
@@ -201,7 +201,10 @@ class SysConfiguration:
             return ''
 
         assert self.linux_os_release is not None
-        version_id = self.linux_os_release.version_id
+        version_id = getattr(self.linux_os_release, 'version_id', None)
+        if not version_id:
+            # Rolling-release distributions have no version.
+            return ''
         if self.is_redhat_family():
             # For RedHat family, only keep the major version.
             num_version_components = 1


### PR DESCRIPTION
Noticed on Arch Linux:
```
Traceback (most recent call last):
  File "/home/deen/git/yugabyte-db/python/yb/thirdparty_tool.py", line 637, in <module>
    main()
  File "/home/deen/git/yugabyte-db/python/yb/thirdparty_tool.py", line 608, in main
    thirdparty_release: Optional[MetadataItem] = get_third_party_release(
  File "/home/deen/git/yugabyte-db/python/yb/thirdparty_tool.py", line 519, in get_third_party_release
    os_type = local_sys_conf().short_os_name_and_version()
  File "/home/deen/git/yugabyte-db/build/venv/lib/python3.10/site-packages/sys_detection/__init__.py", line 191, in short_os_name_and_version
    return '%s%s' % (self.short_os_name(), self.short_os_version())
  File "/home/deen/git/yugabyte-db/build/venv/lib/python3.10/site-packages/sys_detection/__init__.py", line 180, in short_os_version
    version_id = self.linux_os_release.version_id
AttributeError: 'OsReleaseVars' object has no attribute 'version_id'
```
After the fix it still fails (as expected) but at least the error
message is friendlier:
```
[2022-03-16T14:27:43 yugabyte-bash-common.sh:149 detect_os] arch is not a supported Linux distribution
```