### PR TITLE
Add OS compatibility checking (e.g. between various flavors of RedHat)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
             python_version: 3.8
           - os_prefix: ubuntu
             python_version: 3.9
+          - os_prefix: ubuntu
+            python_version: 3.10
           # macOS
           - os_prefix: macos
             python_version: 3.6
@@ -53,6 +55,8 @@ jobs:
             python_version: 3.8
           - os_prefix: macos
             python_version: 3.9
+          - os_prefix: macos
+            python_version: 3.10
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   build:
-    name: ${{ matrix.os_prefix }}-${{ matrix.python_version }}
+    name: ${{ matrix.os_prefix }}-py${{ matrix.python_version }}
     runs-on: ${{ matrix.os_prefix }}-latest
     if: >
       (github.event_name == 'push' &&
@@ -44,8 +44,6 @@ jobs:
             python_version: 3.8
           - os_prefix: ubuntu
             python_version: 3.9
-          - os_prefix: ubuntu
-            python_version: 3.10
           # macOS
           - os_prefix: macos
             python_version: 3.6
@@ -55,8 +53,6 @@ jobs:
             python_version: 3.8
           - os_prefix: macos
             python_version: 3.9
-          - os_prefix: macos
-            python_version: 3.10
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python_version }}

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,11 @@ VENV_NAME?=venv
 VENV_ACTIVATE=. $(VENV_NAME)/bin/activate
 VENV_PYTHON=$(VENV_NAME)/bin/python3
 
-check: venv
+check: venv unittest
 	$(VENV_PYTHON) -m codecheck --python-interpreter "$(VENV_PYTHON)"
 
 unittest: venv
-	$(VENV_PYTHON) -m unittest discover -s tests -p '*_test.py'
+	$(VENV_PYTHON) -m pytest --doctest-modules
 
 venv: $(VENV_NAME)/bin/activate
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
 
     setup(
         name='sys-detection',
-        version='1.2.0',
+        version='1.3.0',
         url='https://github.com/yugabyte/sys-detection',
         author='Mikhail Bautin',
         author_email='mbautin@users.noreply.github.com',
@@ -44,7 +44,8 @@ if __name__ == '__main__':
             'dev': [
                 'codecheck',
                 'pycodestyle',
-                'mypy'
+                'mypy',
+                'pytest',
             ]
         }
     )

--- a/src/sys_detection/__init__.py
+++ b/src/sys_detection/__init__.py
@@ -19,6 +19,9 @@ from typing import Optional, Any, Dict, Optional, List
 
 from autorepr import autorepr  # type: ignore
 
+from sys_detection.os_compatibility import is_compatible_os
+
+
 VALID_ATTR_RE = re.compile('^[a-z_]+$')
 
 SHORT_LINUX_OS_NAMES = [

--- a/src/sys_detection/os_compatibility.py
+++ b/src/sys_detection/os_compatibility.py
@@ -1,0 +1,38 @@
+# Copyright (c) Yugabyte, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations
+# under the License.
+
+import re
+
+
+RHEL_FAMILY_RE = re.compile(r'^(almalinux|centos|rhel|rocky)([0-9]+)$')
+
+
+def is_compatible_os(archive_os: str, target_os: str) -> bool:
+    """
+    Check if two combinations of OS name and version are compatible.
+
+    >>> is_compatible_os('centos7', 'centos8')
+    False
+    >>> is_compatible_os('centos7', 'centos7')
+    True
+    >>> is_compatible_os('almalinux7', 'rhel7')
+    True
+    >>> is_compatible_os('rocky8', 'almalinux8')
+    True
+    >>> is_compatible_os('ubuntu20.04', 'centos8')
+    False
+    """
+    rhel_like1 = RHEL_FAMILY_RE.match(archive_os)
+    rhel_like2 = RHEL_FAMILY_RE.match(target_os)
+    if rhel_like1 and rhel_like2 and rhel_like1.group(2) == rhel_like2.group(2):
+        return True
+    return archive_os == target_os


### PR DESCRIPTION
Also use pytest to run tests, and run doctest tests as part of the "unittest" target. Make the "unittest" target a dependency of the default "check" target. Bump version 1.3.0.